### PR TITLE
fix: 🐛 long.js 有効範囲

### DIFF
--- a/src/utils/long.util.spec.ts
+++ b/src/utils/long.util.spec.ts
@@ -1,0 +1,44 @@
+import Long from 'long';
+import { LongUtil } from './long.util';
+
+describe('LongUtil', () => {
+  describe('fromBigInt', () => {
+    it('should convert bigint to Long', () => {
+      const num = BigInt('9223372036854775807');
+      const long = LongUtil.fromBigInt(num);
+      expect(long).toEqual(Long.fromString('9223372036854775807'));
+
+      const num2 = BigInt('-9223372036854775808');
+      const long2 = LongUtil.fromBigInt(num2);
+      expect(long2).toEqual(Long.fromString('-9223372036854775808'));
+    });
+
+    it("should return undefined if bigint is greater than '9223372036854775807'", () => {
+      const num = BigInt('9223372036854775808');
+      const long = LongUtil.fromBigInt(num);
+      expect(long).toBeUndefined();
+    });
+
+    it("should return undefined if bigint is less than '-9223372036854775808'", () => {
+      const num = BigInt('-9223372036854775809');
+      const long = LongUtil.fromBigInt(num);
+      expect(long).toBeUndefined();
+    });
+  });
+
+  describe('toBigInt', () => {
+    it('should convert Long to bigint', () => {
+      const long = Long.fromString('9223372036854775807');
+      const num = LongUtil.toBigInt(long);
+      expect(num).toEqual(BigInt('9223372036854775807'));
+
+      const long2 = Long.fromString('-9223372036854775808');
+      const num2 = LongUtil.toBigInt(long2);
+      expect(num2).toEqual(BigInt('-9223372036854775808'));
+
+      const long3 = Long.fromString('0');
+      const num3 = LongUtil.toBigInt(long3);
+      expect(num3).toEqual(BigInt('0'));
+    });
+  });
+});

--- a/src/utils/long.util.ts
+++ b/src/utils/long.util.ts
@@ -1,17 +1,17 @@
 import Long from 'long';
 
 export class LongUtil {
-  public static fromBigInt(num: bigint | undefined | null): Long | undefined {
-    if (num === undefined || num === null) {
+  public static fromBigInt(num: bigint) {
+    if (
+      num > BigInt('9223372036854775807') ||
+      num < BigInt('-9223372036854775808')
+    ) {
       return undefined;
     }
-    return Long.fromNumber(Number(num));
+    return Long.fromString(num.toString());
   }
 
-  public static toBigInt(num: Long | undefined | null): bigint | undefined {
-    if (num === undefined || num === null) {
-      return undefined;
-    }
-    return BigInt(num.toNumber());
+  public static toBigInt(num: Long) {
+    return BigInt(num.toString());
   }
 }

--- a/src/utils/long.util.ts
+++ b/src/utils/long.util.ts
@@ -1,11 +1,11 @@
 import Long from 'long';
 
+const POSTGRES_MAX_BIGINT = BigInt('9223372036854775807');
+const POSTGRES_MIN_BIGINT = BigInt('-9223372036854775808');
+
 export class LongUtil {
   public static fromBigInt(num: bigint) {
-    if (
-      num > BigInt('9223372036854775807') ||
-      num < BigInt('-9223372036854775808')
-    ) {
+    if (num > POSTGRES_MAX_BIGINT || num < POSTGRES_MIN_BIGINT) {
       return undefined;
     }
     return Long.fromString(num.toString());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es2017",
+    "target": "ES2017",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
long.js 有効範囲は下記の有効範囲と違う、

- JavaScript `number` `bigint` 有効範囲
- PostgreSQL `bigint` 有効範囲、

![image](https://github.com/plugoinc/node-common/assets/17308201/054d693e-4e6b-4dd3-888c-1c05600364e9)
