### PR TITLE
feat: 🎸 protobuf.util toCamelCase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,16 @@
 {
   "name": "@plugoinc/common",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plugoinc/common",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
-      "dependencies": {
-        "long": "^5.2.3"
-      },
       "devDependencies": {
         "@types/jest": "^29.5.5",
+        "@types/lodash": "^4.14.200",
         "@types/node": "^20.6.3",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
@@ -24,6 +22,10 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
+      },
+      "peerDependencies": {
+        "lodash": "^4.17.21",
+        "long": "^5.2.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1433,6 +1435,12 @@
       "version": "7.0.14",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
       "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.200",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -4070,6 +4078,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4085,7 +4099,8 @@
     "node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "test:cov": "jest --coverage"
   },
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
+    "lodash": "^4.17.21",
     "long": "^5.2.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",
+    "@types/lodash": "^4.14.200",
     "@types/node": "^20.6.3",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",

--- a/src/utils/protobuf.util.spec.ts
+++ b/src/utils/protobuf.util.spec.ts
@@ -1,0 +1,20 @@
+import { toCamelCase } from './protobuf.util';
+
+describe('protobuf.util', () => {
+  it('should be covered to camelCase', () => {
+    const any_case = {
+      snake_case: 'snake_case value',
+      snake_case_2: 'snake_case_2 value',
+      camelCase: 'camelCase value',
+      'other-case': 'other-case value',
+    };
+    const camelCase = {
+      snakeCase: 'snake_case value',
+      snakeCase2: 'snake_case_2 value',
+      camelCase: 'camelCase value',
+      otherCase: 'other-case value',
+    };
+
+    expect(toCamelCase(any_case)).toEqual(camelCase);
+  });
+});

--- a/src/utils/protobuf.util.ts
+++ b/src/utils/protobuf.util.ts
@@ -1,0 +1,10 @@
+import { camelCase } from 'lodash';
+
+export function toCamelCase<T>(data: Record<string, any>): T {
+  return Object.entries(data).reduce((acc, [key, value]) => {
+    return {
+      ...acc,
+      [camelCase(key)]: value,
+    };
+  }, {} as T);
+}


### PR DESCRIPTION
`toCamelCase` can be used in `toPb` for transforming Prisma data to Protobuf data, since we are use `snake_case` in Prisma and use `camcelCase` in Protobuf.

like: 
![image](https://github.com/plugoinc/node-common/assets/17308201/4b61c9f9-318a-42a6-b72e-c4e7a7f77059)



